### PR TITLE
feat(docker): add Docker deployment (all-in-one image + optional split PostgreSQL)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /.clj-kondo/
 /.lsp/
+/.env
 /archive
 /audits-archiver
 /integration

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ An up-to-date, human-readable specification of all our scenarios is to be found 
 
 All the important information is to be found [here](https://github.com/leihs/leihs/wiki).
 
+# Docker
+
+A Docker deployment (all-in-one container image + optional split PostgreSQL
+container) is available under [`docker/`](docker/README.md). It converts the
+Ansible deployment ([leihs_deploy](https://github.com/leihs/leihs_deploy))
+into containers while keeping the exact same service layout and configuration
+variables.
+
 # Issues
 
 All present and past issues are tracked, discussed and dealt with [here](https://github.com/leihs/leihs/issues).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,166 @@
+# syntax=docker/dockerfile:1
+#
+# leihs-docker — All-in-one container image for leihs
+# (equipment booking & inventory management system, https://github.com/leihs/leihs)
+#
+# This image reproduces the single-server installation of the official
+# Ansible deployment (https://github.com/leihs/leihs_deploy) in a container:
+# PostgreSQL 15 + Apache2 reverse proxy + all leihs services.
+#
+# The source is the leihs/leihs super-repository (pinning all service
+# submodules: legacy, database, admin, borrow, procure, my, mail, inventory)
+# at exactly the revision the Ansible deployment would deploy.
+#
+# Build arguments:
+#   LEIHS_REF      Branch/tag/commit of the leihs super-repo (default: master)
+#   LEIHS_VERSION  Version string for config.env / display (default: unknown)
+#   BASE_IMAGE     Base image (default: debian:bookworm-slim)
+#
+# Build (context = this directory):
+#   docker build -t leihs-docker:latest docker/
+#
+# The build clones the super-repo from GitHub at build time (including all
+# submodules), so the build context itself needs no source files.
+
+ARG BASE_IMAGE=debian:bookworm-slim
+
+###############################################################################
+# Stage 1: build — toolchain (mise) + source + build all artifacts          #
+###############################################################################
+FROM ${BASE_IMAGE} AS build
+
+ARG LEIHS_REF=master
+ARG LEIHS_VERSION=unknown
+ARG DEBIAN_FRONTEND=noninteractive
+
+# --- System build dependencies --------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl git gnupg jq \
+        build-essential pkg-config unzip xz-utils \
+        libpq-dev libyaml-dev libreadline-dev zlib1g-dev libssl-dev \
+        libffi-dev libgdbm-dev libncurses-dev libxml2-dev libxslt1-dev \
+        shared-mime-info \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- mise (version manager used by the leihs build scripts) ---------------------
+RUN curl -fsSL https://mise.jdx.dev/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+
+# --- Source checkout --------------------------------------------------------------
+# leihs super-repo including all submodules (legacy, database, admin, borrow,
+# procure, my, mail, inventory, ...). --depth 1 saves time; when LEIHS_REF is a
+# commit SHA it is fetched afterwards.
+WORKDIR /src
+RUN if [ "${LEIHS_REF}" = "master" ]; then \
+        git clone --depth 1 https://github.com/leihs/leihs.git /src/leihs; \
+    else \
+        git clone --depth 1 --branch "${LEIHS_REF}" https://github.com/leihs/leihs.git /src/leihs \
+        || ( git clone --depth 1 https://github.com/leihs/leihs.git /src/leihs \
+             && cd /src/leihs && git fetch --depth 1 origin "${LEIHS_REF}" && git checkout FETCH_HEAD ); \
+    fi \
+    && cd /src/leihs \
+    && git submodule update --init --recursive --depth 1 \
+    && (git describe --tags --always || true) > /tmp/leihs_version_actual \
+    && printf '%s' "${LEIHS_VERSION}" > /tmp/leihs_version_arg
+
+# --- Install the toolchain from .tool-versions (single source of truth) ----------
+# Root .tool-versions: babashka, clojure, java temurin-21, nodejs, ruby 3.3.8.
+# Some sub-projects pin different nodejs versions — those are installed
+# explicitly below. firefox/geckodriver (tests only) are intentionally NOT
+# installed; the build scripts do not call them.
+RUN cd /src/leihs && mise install
+RUN for d in admin borrow procure my mail inventory legacy database; do \
+        cd /src/leihs/${d} && mise install nodejs ruby >/dev/null; \
+    done
+
+# --- Clojure/JS services: ./bin/build produces the fat jars -----------------------
+# (bin/build internally runs `mise install ruby` + `bundle install`)
+RUN cd /src/leihs/admin     && mise exec -- ./bin/build
+RUN cd /src/leihs/borrow    && mise exec -- ./bin/build
+RUN cd /src/leihs/procure   && mise exec -- ./bin/build
+RUN cd /src/leihs/my        && mise exec -- ./bin/build
+RUN cd /src/leihs/mail      && mise exec -- ./bin/build
+RUN cd /src/leihs/inventory && mise exec -- ./bin/build
+
+# --- Ruby apps: bundle install (legacy + database) ---------------------------------
+# Local into vendor/bundle so the gems are carried over into the runtime image.
+RUN cd /src/leihs/legacy   && mise exec -- bundle config set --local path vendor/bundle \
+    && mise exec -- bundle install
+RUN cd /src/leihs/database && mise exec -- bundle config set --local path vendor/bundle \
+    && mise exec -- bundle install
+
+###############################################################################
+# Stage 2: runtime — PostgreSQL + Apache + Ruby + Java + leihs                #
+###############################################################################
+FROM ${BASE_IMAGE} AS runtime
+
+ARG POSTGRES_VERSION=15
+ARG LEIHS_VERSION=unknown
+ARG DEBIAN_FRONTEND=noninteractive
+ENV LEIHS_VERSION_BUILD=${LEIHS_VERSION}
+
+# --- Base packages ---------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg locales procps tzdata \
+        apache2 ssl-cert awstats \
+        libyaml-0-2 libssl3 zlib1g libffi8 libgdbm6 libreadline8 libncursesw6 \
+        libpq5 libxml2 libxslt1.1 shared-mime-info \
+        fontconfig fonts-liberation \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo "de_CH.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen
+
+# --- PostgreSQL ${POSTGRES_VERSION} from the pgdg repo (like the Ansible deploy) --
+RUN install -d /etc/apt/keyrings \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/keyrings/pgdg.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/pgdg.gpg] https://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        postgresql-${POSTGRES_VERSION} postgresql-client-${POSTGRES_VERSION} \
+    && rm -rf /var/lib/apt/lists/* \
+    && PGCONF=$(find /etc/postgresql -name postgresql.conf | head -1) \
+    && sed -i "s/^#\?port = .*/port = 5415/" "${PGCONF}"
+
+# --- Ruby + Java from the build stage (exact .tool-versions versions) --------------
+COPY --from=build /root/.local/share/mise/installs/ruby/* /opt/mise/ruby/
+COPY --from=build /root/.local/share/mise/installs/java/* /opt/mise/java/
+RUN RUBY_DIR=$(ls -d /opt/mise/ruby/*/ | head -1) \
+    && JAVA_DIR=$(ls -d /opt/mise/java/*/ | head -1) \
+    && ln -s "${RUBY_DIR%/}" /opt/ruby \
+    && ln -s "${JAVA_DIR%/}" /opt/java
+ENV PATH="/opt/ruby/bin:/opt/java/bin:${PATH}" \
+    JAVA_HOME=/opt/java
+
+# --- leihs apps: legacy + database (complete), services as jars ---------------------
+COPY --from=build /src/leihs/legacy /leihs/legacy
+COPY --from=build /src/leihs/database /leihs/database
+COPY --from=build /src/leihs/admin/target/leihs-admin.jar         /leihs/admin/leihs-admin.jar
+COPY --from=build /src/leihs/borrow/target/leihs-borrow.jar       /leihs/borrow/leihs-borrow.jar
+COPY --from=build /src/leihs/procure/server/target/leihs-procure.jar /leihs/procure/leihs-procure.jar
+COPY --from=build /src/leihs/my/target/leihs-my.jar               /leihs/my/leihs-my.jar
+COPY --from=build /src/leihs/mail/target/leihs-mail.jar           /leihs/mail/leihs-mail.jar
+COPY --from=build /src/leihs/inventory/target/leihs-inventory.jar /leihs/inventory/leihs-inventory.jar
+RUN rm -rf /leihs/legacy/.git /leihs/database/.git \
+    && mkdir -p /leihs/legacy/{log,tmp,storage,public/system} \
+    && mkdir -p /leihs/database/{log,tmp} \
+    && mkdir -p /leihs/{admin,borrow,procure,my,mail,inventory}/{logs,tmp} \
+    && mkdir -p /leihs/var/db-backups /leihs/config /var/log/leihs /etc/leihs
+
+# --- Entrypoint, scripts, Apache configuration --------------------------------------
+COPY entrypoint.sh /usr/local/bin/leihs-entrypoint
+COPY scripts/ /usr/local/lib/leihs/
+COPY apache/ /etc/apache2/leihs/
+RUN chmod +x /usr/local/bin/leihs-entrypoint /usr/local/lib/leihs/*.sh \
+    && a2enmod proxy proxy_http rewrite alias headers expires ssl cache cache_disk unique_id setenvif env cgid
+
+# --- Ports & healthcheck --------------------------------------------------------------
+EXPOSE 80 443
+HEALTHCHECK --interval=30s --timeout=5s --start-period=300s --retries=3 \
+    CMD curl -fsS "http://localhost/status" >/dev/null 2>&1 || exit 1
+
+ENTRYPOINT ["/usr/local/bin/leihs-entrypoint"]
+
+# Volumes (persistent data):
+#   /var/lib/postgresql          PostgreSQL data
+#   /leihs/var                   master_secret, DB backups
+#   /leihs/legacy/storage        ActiveStorage uploads (images, attachments)
+VOLUME ["/var/lib/postgresql", "/leihs/var", "/leihs/legacy/storage"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -237,6 +237,23 @@ chown the volume once via a temporary root helper container.
 `setcap` is a small privilege extension. The image default stays root for
 compatibility; non-root is a documented option.
 
+**Trade-offs to be aware of:**
+- **Ongoing maintenance:** the Ansible reference deployment runs as root;
+  non-root is a permanent delta branch — every upstream change needs an
+  ownership review.
+- **Upgrade path:** existing root-run volumes are root-owned; switching to
+  non-root requires a one-time `chown` (via a temporary root helper
+  container). Named volumes inherit the image ownership only on first use.
+- **`setcap` conflicts with `no-new-privileges`:** `no_new_privs` prevents
+  file capabilities from being granted at `exec` — with
+  `no-new-privileges:true` Apache cannot bind 80/443 even with `setcap`
+  (use the high-port variant instead).
+- **TLS certificates:** certbot/Let's-Encrypt typically runs as root;
+  renewal must move outside the container (host cron + read-only mount).
+- **No boundary against the host:** without user namespaces, UID 1000 in
+  the container maps to UID 1000 on the host — relevant for bind mounts on
+  multi-user hosts. Real isolation would require rootless/userns-remap.
+
 ## 9. Troubleshooting
 
 | Symptom | Cause / fix |

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,199 @@
+# leihs-docker
+
+Docker deployment for **[leihs](https://github.com/leihs/leihs)** — the
+equipment booking & inventory management system by ZHdK (GPLv3).
+
+This directory converts the official **Ansible installation**
+([leihs/leihs_deploy](https://github.com/leihs/leihs_deploy)) to Docker.
+The image contains PostgreSQL 15, an Apache2 reverse proxy and all leihs
+services (legacy, database, admin, borrow, procure, my, mail, inventory) —
+mirroring the single-machine layout of the Ansible deployment. The
+`compose.yaml` additionally offers a **split mode**: PostgreSQL as its own
+container (recommended). The app talks to the database over TCP via
+`DB_HOST`/`DB_PORT` in both modes.
+
+> This is a contribution proposal to the leihs project. A maintained
+> reference implementation lives in the
+> [leihs-docker](https://github.com/tilllt/leihs-docker) repository (public
+> mirror of a private repo).
+
+---
+
+## 1. Architecture
+
+**Split mode (compose default):**
+
+```
+                        ┌──────────────────────────────────────────┐
+ Browser ── 80/443 ──►  │  Apache2 (reverse proxy, mod_proxy)      │
+                        │  ├─ /            → leihs-my        :3240  │
+                        │  ├─ /admin       → leihs-admin     :3220  │
+                        │  ├─ /borrow      → leihs-borrow    :3250  │
+                        │  ├─ /procure     → leihs-procure   :3230  │
+                        │  ├─ /inventory   → leihs-inventory :3260  │  (optional)
+                        │  ├─ /assets      → static (legacy/public)│
+                        │  └─ /status …    → leihs-legacy    :3210  │
+                        └───────────────┬──────────────────────────┘
+                                        │ TCP db:5415 (internal network)
+                        ┌───────────────▼──────────────────────────┐
+                        │  container "db" (postgres:15, port 5415) │
+                        │  DB leihs, role root                     │
+                        └──────────────────────────────────────────┘
+   leihs-mail (no HTTP port, worker)  │  leihs-legacy-cron (daily 04:00)
+```
+
+**Single-container mode** (`DB_HOST=localhost`, image alone): identical
+layout, but the bundled PostgreSQL (pgdg, port 5415) runs in the same
+container instead of the `db` service.
+
+All client connections (Rails `database.yml`, Java services via
+`config.env`, `init-db.sh`) always go **over TCP** against
+`DB_HOST:DB_PORT` — a single code path for both modes. The local cluster is
+only started by `init-db.sh` when `DB_HOST` points to `localhost`.
+
+## 2. How it works
+
+The image is built in two stages:
+
+- **Stage `build`** (debian:bookworm-slim + [mise](https://mise.jdx.dev/)):
+  clones the `leihs/leihs` super-repo at the pinned `LEIHS_REF` (default
+  `master`) including all submodules, installs the exact toolchain from
+  `.tool-versions` (Ruby 3.3.8, Java Temurin 21, Node, Clojure), builds the
+  Clojure fat jars (`./bin/build`) and installs the Ruby gems for `legacy`
+  and `database` into `vendor/bundle`.
+- **Stage `runtime`** (debian:bookworm-slim): PostgreSQL 15 from the pgdg
+  repo (like `roles/postgresql`, port 5415), Apache2 with all proxy modules,
+  Ruby/Java copied from the build stage, all leihs apps under `/leihs/…`.
+
+On container start (`entrypoint.sh`) the exact step sequence of the Ansible
+deployment runs (all steps are idempotent):
+
+| Step | Ansible equivalent | Implementation |
+|---|---|---|
+| 1. Defaults | `defaults.yml` | env variables with identical defaults |
+| 2. Master secret | `roles/configure` (`master_secret.txt`) | auto-generated & persisted in `/leihs/var/master_secret` |
+| 3. Render config | `roles/configure`, `roles/leihs-legacy-install`, `roles/reverse-proxy-leihs`, `roles/webstats` | `scripts/render-config.sh`: `config.env` (incl. `DB_HOST`), `database.yml` (legacy **and** database app), `puma.rb`, Apache vhosts, AWStats |
+| 4. Init DB | `roles/postgresql` + `roles/leihs-database-install` | `scripts/init-db.sh`: client steps (role `root` SUPERUSER/CREATEDB, DB `root`, DB `leihs` with ICU `de-CH`/UTF8/template0, `structure.sql` + `seeds.sql` with `session_replication_role=REPLICA`) always over TCP against `DB_HOST:DB_PORT`; the bundled cluster is only created/started when `DB_HOST=localhost` |
+| 5. Migrations | `leihs-migration.service` (oneshot) | `bundle exec rake db:migrate` in `/leihs/database` (RAILS_ENV=production) |
+| 6. Start services | `roles/start-services` + systemd units | `scripts/start-services.sh`: supervisor with restart loops (systemd `Restart=always` behavior), Apache + Puma + jars + cron loop, clean SIGTERM handling |
+
+## 3. Quick start
+
+```bash
+# Configuration (optional — all values have defaults):
+cp docker/example.env .env        # adjust, e.g. LEIHS_EXTERNAL_HOSTNAME, DB_PASSWORD
+
+# Variant A: docker compose — split mode (PostgreSQL as its own container)
+docker compose -f docker/compose.yaml up -d
+docker compose -f docker/compose.yaml logs -f
+
+# Variant B: docker run — single-container mode (bundled PostgreSQL)
+docker build -t leihs-docker:latest docker/
+docker run -d --name leihs \
+  -p 80:80 -p 443:443 \
+  -e LEIHS_EXTERNAL_HOSTNAME=leihs.example.org \
+  -e DB_HOST=localhost \
+  -v pgdata:/var/lib/postgresql \
+  -v leihs-data:/leihs/var \
+  -v leihs-storage:/leihs/legacy/storage \
+  leihs-docker:latest
+```
+
+The only difference between the modes is `DB_HOST`: `db` (compose, split) or
+`localhost` (single container). `init-db.sh` initializes the database over
+TCP in both cases — the role `root`, the database `leihs` (ICU `de-CH`) and
+`structure.sql`/`seeds.sql` are created automatically.
+
+Afterwards:
+
+- `http://localhost/` → leihs-my (login page)
+- `http://localhost/admin` → admin
+- `http://localhost/borrow` → borrow (booking)
+- `http://localhost/status` → health check route (legacy)
+- Initial login data: see the
+  [leihs wiki (live demo accounts)](https://github.com/leihs/leihs/wiki#live-demo)
+  — the seeds (admin users) come from `seeds.sql` of the `leihs_database` repo.
+
+**Important first configuration:** change `DB_PASSWORD` (or set
+`LEIHS_MASTER_SECRET`), set `LEIHS_EXTERNAL_HOSTNAME` to the real hostname,
+and configure SMTP via the admin UI (mail settings live in the `smtp_settings`
+table, as in the Ansible deployment).
+
+## 4. Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `LEIHS_EXTERNAL_HOSTNAME` | `leihs.example.org` | ServerName of the vhosts |
+| `LEIHS_MASTER_SECRET` | auto-generated | Rails/jar secret (40 chars); persisted under `/leihs/var/master_secret` |
+| `DB_HOST` / `DB_PORT` | `db` / `5415` | PostgreSQL connection (compose: service name `db`; single container: `localhost`). All clients use TCP |
+| `DB_NAME` / `DB_USER` / `DB_PASSWORD` | `leihs` / `root` / `root` | **Change the password in production!** |
+| `PUBLISH_INVENTORY` | `false` | `true` starts the inventory service and enables the `/inventory` route |
+| `ENABLE_AUTH_HEADER_PREFIX_BASIC` | `true` | `ENABLE_AUTH_HEADER_PREFIX_BASIC` in config.env |
+| `RESTRICT_ACCESS_VIA_BASIC_AUTH` | `false` | protect the whole access with basic auth |
+| `RESTRICT_ACCESS_VIA_BASIC_AUTH_PASSWORDS` | — | `"user:pass,user2:pass2"` |
+| `WEBSTATS_ENABLED` | `true` | AWStats under `/webstats` |
+| `LEIHS_PUMA_WORKERS` / `LEIHS_PUMA_THREADS` | `2` / `5` | Puma workers/threads (Ansible: vCPUs / 5) |
+| `LEIHS_CRON_TIME` | `04:00` | daily `rake leihs:cron` run |
+| `LEIHS_CRON_RANDOMIZED_DELAY_MAX_SECONDS` | `3600` | random delay (Ansible default) |
+| `LEIHS_JAVA_XMX_<SERVICE>` | 1G / 500m | heap size per jar (Ansible defaults) |
+| `LEIHS_DB_MAX_POOL_SIZE` | `20` | DB pool of the jars (my/mail: 10) |
+| `LEIHS_IP_HASH_SEED` | hostname | seed for IP anonymization in the access log |
+
+## 5. Persistent data (volumes)
+
+| Volume | Content |
+|---|---|
+| `pgdata` | PostgreSQL cluster (database `leihs`) — split mode: on the `db` service (`/var/lib/postgresql/data`); single-container mode: on the app container (`/var/lib/postgresql`) |
+| `leihs-data` | `master_secret`, DB backups, IP hash seed |
+| `leihs-storage` | ActiveStorage uploads (images, attachments) |
+
+## 6. Backup & restore
+
+```bash
+# Split mode: directly against the DB container
+docker exec leihs-db pg_dump -U root -d leihs > leihs-$(date +%F).sql
+
+# Single-container mode: inside the app container
+docker exec leihs pg_dump -h localhost -p 5415 -U root leihs > leihs-$(date +%F).sql
+
+# Additionally back up the uploads:
+docker cp leihs:/leihs/legacy/storage ./storage
+```
+
+Restore:
+
+```bash
+# Split mode
+docker exec -i leihs-db psql -U root -d leihs < leihs-2026-01-01.sql
+
+# Single-container mode
+docker exec -i leihs psql -h localhost -p 5415 -U root leihs < leihs-2026-01-01.sql
+```
+
+**Migrating single container → split:** dump once from the old system, then
+`docker compose -f docker/compose.yaml up -d` (the `db` container starts
+empty) and restore as above.
+
+## 7. Differences to the Ansible deployment (by design)
+
+- **No system users** (`leihs-legacy`, `leihs-admin`, …): the container runs
+  as root; Docker provides the isolation.
+- **No SSH/Ansible control plane:** deployment = image build + container
+  start; "redeploy" = `docker compose pull && up -d`.
+- **`leihs_inventory`** is optional (default off), as in the Ansible deploy.
+- **DB backup** is not built in — `pg_dump` from outside (see §6).
+- **PostgreSQL split** is an additional option: the bundled PostgreSQL stays
+  for the single-container mode; the compose default runs PostgreSQL as its
+  own container on the internal network (no port exposed to the host).
+
+## 8. Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| Container starts, healthcheck green, but `/` does not load | Puma needs up to ~60 s; check `docker logs leihs` |
+| `502` on `/inventory` | `PUBLISH_INVENTORY` is `false` (service not running) |
+| Login fails / sessions broken | `LEIHS_MASTER_SECRET` changed → keep the secret in `/leihs/var/master_secret` or env stable |
+| DB init fails | leave volumes empty or back up the DB consistently; `docker logs` shows the exact step |
+| `db` container not ready | `docker compose -f docker/compose.yaml logs db`; healthcheck runs `pg_isready` (port `DB_PORT`, `start_period` 30 s) |
+| Migration error | `docker compose -f docker/compose.yaml exec leihs bash -lc 'cd /leihs/database && RAILS_ENV=production bundle exec rake db:migrate'` |
+| Apache config error on start | `docker exec leihs apache2ctl -t` |

--- a/docker/README.md
+++ b/docker/README.md
@@ -186,7 +186,58 @@ empty) and restore as above.
   for the single-container mode; the compose default runs PostgreSQL as its
   own container on the internal network (no port exposed to the host).
 
-## 8. Troubleshooting
+## 8. Running the container non-root (optional)
+
+By default the container runs as root, mirroring the Ansible deployment.
+To run the container processes without root (UID 1000, **not** Rootless
+Docker — the daemon stays root), the following changes are needed:
+
+**Dockerfile:**
+```dockerfile
+RUN useradd -r -u 1000 -m -s /bin/bash leihs
+# writable paths + PostgreSQL data dir, owned by the user (named volumes
+# inherit the image ownership on first use)
+RUN chown -R leihs:leihs /leihs /etc/leihs /var/log/leihs \
+      /run/apache2 /var/lock/apache2 /var/cache/apache2 \
+      /etc/apache2/sites-available /etc/apache2/sites-enabled \
+      /etc/awstats/awstats.conf /var/lib/postgresql
+RUN usermod -aG ssl-cert leihs     # read the snakeoil private key
+# ...
+USER leihs
+```
+
+**`init-db.sh`:** replace the Debian cluster wrappers (root-only
+`pg_createcluster`/`pg_ctlcluster`) with a user-space `initdb` + `pg_ctl`;
+the bootstrap superuser becomes the app user itself:
+```bash
+initdb -D "${PGDATA}" -U "${DB_USER}" -E UTF8 --locale=C.UTF-8 \
+  --pwfile=<(printf '%s' "${DB_PASSWORD}") \
+  --auth-host=scram-sha-256 --auth-local=trust
+echo "port = ${DB_PORT}" >> "${PGDATA}/postgresql.conf"   # 5415 > 1024
+pg_ctl -D "${PGDATA}" -o "-p ${DB_PORT} -k /tmp" -w start
+```
+The `su postgres` peer-auth bootstrap is dropped entirely; all client steps
+already run over TCP. In split mode this block is inactive anyway.
+
+**Apache:** either render high ports (8080/8443, mapped to 80/443 in
+compose), or keep 80/443 with a file capability:
+`RUN setcap cap_net_bind_service=+ep /usr/sbin/apache2`
+(`NET_BIND_SERVICE` is in the Docker default capability set).
+
+**compose:** `user: "1000:1000"` on both services (plus optional
+`read_only`, `tmpfs`, `cap_drop: [ALL]`, `no-new-privileges`).
+**Volume pitfall:** named volumes inherit the image ownership on first use —
+for a non-root `postgres:15` use a bind mount pre-owned by UID 1000 or
+chown the volume once via a temporary root helper container.
+
+**Verify:** `docker exec leihs id` → `uid=1000(leihs)`;
+`psql -h 127.0.0.1 -p 5415 -U root -d leihs -c "select 1"`.
+
+**Limits:** this is *not* Rootless Docker (the daemon remains root), and
+`setcap` is a small privilege extension. The image default stays root for
+compatibility; non-root is a documented option.
+
+## 9. Troubleshooting
 
 | Symptom | Cause / fix |
 |---|---|

--- a/docker/apache/basic-auth.conf.tpl
+++ b/docker/apache/basic-auth.conf.tpl
@@ -1,0 +1,13 @@
+# leihs-docker: Basic-Auth-Fragment
+# Konvertiert aus leihs_deploy roles/reverse-proxy-leihs/templates/basic_auth.conf.
+# Wird von render-config.sh aktiviert, wenn RESTRICT_ACCESS_VIA_BASIC_AUTH=true.
+
+<LocationMatch "^(?!/webstats.*|/admin.*)">
+    AuthType Basic
+    AuthName "Access to Leihs on __LEIHS_EXTERNAL_HOSTNAME__ is restricted"
+    AuthBasicProvider file
+    AuthUserFile "/etc/leihs/leihs.htpasswd"
+    Require valid-user
+</LocationMatch>
+
+# vim: syntax=apache

--- a/docker/apache/leihs-main.conf
+++ b/docker/apache/leihs-main.conf
@@ -1,0 +1,152 @@
+# leihs-docker: Apache2 Reverse-Proxy Hauptkonfiguration
+# Konvertiert aus leihs_deploy roles/reverse-proxy-leihs/templates/main.conf.
+# Ports entsprechen den Ansible-Defaults (defaults.yml).
+
+###############################################################################
+### Services Ports ############################################################
+###############################################################################
+
+Define LEIHS_LEGACY_HTTP_PORT 3210
+Define LEIHS_ADMIN_HTTP_PORT 3220
+Define LEIHS_PROCURE_HTTP_PORT 3230
+Define LEIHS_PROCURE_CLIENT_HTTP_PORT 3231
+Define LEIHS_MY_HTTP_PORT 3240
+Define LEIHS_INVENTORY_HTTP_PORT 3260
+Define LEIHS_BORROW_HTTP_PORT 3250
+
+
+###############################################################################
+### General apache config #####################################################
+###############################################################################
+
+AllowEncodedSlashes NoDecode
+RewriteEngine on
+ProxyAddHeaders On
+
+# some get requests require longer parameters, apache 2.4 default is 8192
+LimitRequestLine 32760
+
+DocumentRoot /leihs/legacy/public
+<Directory /leihs/legacy/public >
+  Require all granted
+</Directory>
+
+
+###############################################################################
+### Legacy Assets #############################################################
+###############################################################################
+
+ProxyPass /assets !
+
+Alias /assets /leihs/legacy/public/assets
+<Directory /leihs/legacy/public/assets>
+    Require all granted
+</Directory>
+
+<LocationMatch "^/assets/.*$">
+    Header unset ETag
+    FileETag None
+    # RFC says only cache for 1 year
+    ExpiresActive On
+    ExpiresDefault "access plus 1 year"
+</LocationMatch>
+
+
+
+###############################################################################
+### Reverse proxy #############################################################
+###############################################################################
+
+
+RewriteRule ^/admin/users$ /admin/users/ [R]
+RewriteRule ^/admin/top$ /admin/ [R]
+RewriteRule ^/app/borrow(.*)$ /borrow$1 [R]
+RewriteRule ^/borrow$ /borrow/ [R]
+
+## my
+ProxyPassMatch "^/$"            http://localhost:${LEIHS_MY_HTTP_PORT}                  nocanon retry=0
+ProxyPass      /my              http://localhost:${LEIHS_MY_HTTP_PORT}/my               nocanon retry=0
+ProxyPass      /user            http://localhost:${LEIHS_MY_HTTP_PORT}/user             nocanon retry=0
+ProxyPass      /sign-in         http://localhost:${LEIHS_MY_HTTP_PORT}/sign-in          nocanon retry=0
+ProxyPass      /sign-out        http://localhost:${LEIHS_MY_HTTP_PORT}/sign-out         nocanon retry=0
+ProxyPass      /forgot-password http://localhost:${LEIHS_MY_HTTP_PORT}/forgot-password  nocanon retry=0
+ProxyPass      /reset-password  http://localhost:${LEIHS_MY_HTTP_PORT}/reset-password   nocanon retry=0
+ProxyPass      /translations    http://localhost:${LEIHS_MY_HTTP_PORT}/translations     nocanon retry=0
+
+## legacy admin
+ProxyPass /admin/audits          http://localhost:${LEIHS_LEGACY_HTTP_PORT}/admin/audits            nocanon retry=0
+ProxyPass /admin/inventory/csv          http://localhost:${LEIHS_LEGACY_HTTP_PORT}/admin/inventory/csv         nocanon retry=0
+ProxyPass /admin/inventory/excel        http://localhost:${LEIHS_LEGACY_HTTP_PORT}/admin/inventory/excel       nocanon retry=0
+ProxyPass /admin/inventory/quick_csv    http://localhost:${LEIHS_LEGACY_HTTP_PORT}/admin/inventory/quick_csv   nocanon retry=0
+ProxyPass /admin/inventory/quick_excel  http://localhost:${LEIHS_LEGACY_HTTP_PORT}/admin/inventory/quick_excel nocanon retry=0
+# Note: Users UI is in new admin, but the search backend from old admin is still needed
+ProxyPass /admin/users.json      http://localhost:${LEIHS_LEGACY_HTTP_PORT}/admin/users.json        nocanon retry=0
+
+
+## admin & API
+ProxyPass /admin   http://localhost:${LEIHS_ADMIN_HTTP_PORT}/admin                          nocanon retry=0 keepalive=On timeout=180
+
+## new borrow
+ProxyPass /borrow   http://localhost:${LEIHS_BORROW_HTTP_PORT}/borrow					nocanon retry=0
+
+## new inventory
+ProxyPass /inventory   http://localhost:${LEIHS_INVENTORY_HTTP_PORT}/inventory				nocanon retry=0
+
+# procure2
+ProxyPass /procure http://localhost:${LEIHS_PROCURE_HTTP_PORT}/procure						nocanon retry=0
+
+## legacyroutes
+ProxyPass /status         http://localhost:${LEIHS_LEGACY_HTTP_PORT}/status         nocanon retry=0
+ProxyPass /categories     http://localhost:${LEIHS_LEGACY_HTTP_PORT}/categories     nocanon retry=0
+ProxyPass /category_links http://localhost:${LEIHS_LEGACY_HTTP_PORT}/category_links nocanon retry=0
+ProxyPass /styleguide     http://localhost:${LEIHS_LEGACY_HTTP_PORT}/styleguide     nocanon retry=0
+ProxyPass /models         http://localhost:${LEIHS_LEGACY_HTTP_PORT}/models         nocanon retry=0
+ProxyPass /properties     http://localhost:${LEIHS_LEGACY_HTTP_PORT}/properties     nocanon retry=0
+ProxyPass /images         http://localhost:${LEIHS_LEGACY_HTTP_PORT}/images         nocanon retry=0
+ProxyPass /attachments    http://localhost:${LEIHS_LEGACY_HTTP_PORT}/attachments    nocanon retry=0
+# admin routes see above
+ProxyPass /manage         http://localhost:${LEIHS_LEGACY_HTTP_PORT}/manage         nocanon retry=0
+
+
+
+###############################################################################
+### Cache #####################################################################
+###############################################################################
+
+# DiskCache
+# seems to require an absolute path and the directory must exits;
+# there will be no error otherwise; the cache just doesn't work
+CacheRoot /tmp
+
+CacheEnable disk "/"
+# default CacheMaxFileSize is 10MB, leihs main.js files tend to be slightly larger
+CacheMaxFileSize 50000000
+
+CacheQuickHandler on
+CacheHeader on
+CacheIgnoreHeaders Set-Cookie Cookie Cookie2 X-Forwarded-For X-Forwarded-Host
+
+
+
+###############################################################################
+## logging ####################################################################
+###############################################################################
+
+RequestHeader set http-uid %{UNIQUE_ID}e
+
+Define IP_HASH_SEED "__IP_HASH_SEED__"
+
+SetEnvIfExpr "md5(%{REMOTE_ADDR}.'${IP_HASH_SEED}') =~ /(.{10})$/ " REMOTE_IPHASH=$1
+
+
+LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\" \"%{http-uid}i\" %{REMOTE_IPHASH}e" custom-access
+
+
+ErrorLog ${APACHE_LOG_DIR}/leihs_leihs_error.log
+LogLevel error
+
+
+CustomLog ${APACHE_LOG_DIR}/leihs_leihs_access.log custom-access
+CustomLog ${APACHE_LOG_DIR}/leihs_leihs_cache.log  "%t SOURCE-IP=%a CACHE-STATUS='%{cache-status}e' URL=%U USER-AGENT='%{User-agent}i'"
+
+# vim: syntax=apache

--- a/docker/apache/vhost-http.conf.tpl
+++ b/docker/apache/vhost-http.conf.tpl
@@ -1,0 +1,24 @@
+# leihs-docker: HTTP-VHost (Port 80)
+# Konvertiert aus leihs_deploy roles/reverse-proxy-leihs/templates/http.conf.
+# __LEIHS_EXTERNAL_HOSTNAME__ wird beim Containerstart von render-config.sh ersetzt.
+
+<VirtualHost *:80>
+
+  ServerName __LEIHS_EXTERNAL_HOSTNAME__
+
+  RewriteEngine on
+
+  Include /etc/apache2/leihs/conf.d/*.conf
+
+  ###############################################################################
+  ### logging ###################################################################
+  ###############################################################################
+
+  #ErrorLog ${APACHE_LOG_DIR}/leihs_default_error.log
+  #LogLevel error
+
+  #CustomLog ${APACHE_LOG_DIR}/leihs_default_access.log combined
+
+
+</VirtualHost>
+# vim: syntax=apache

--- a/docker/apache/vhost-https.conf.tpl
+++ b/docker/apache/vhost-https.conf.tpl
@@ -1,0 +1,37 @@
+# leihs-docker: HTTPS-VHost (Port 443)
+# Konvertiert aus leihs_deploy roles/reverse-proxy-leihs/templates/https.conf.
+# Verwendet das Snakeoil-Zertifikat — für den Produktivbetrieb eigene
+# Zertifikate als Volume unter /etc/ssl/certs|private bereitstellen
+# (LEIHS_SSL_CERT_FILE / LEIHS_SSL_KEY_FILE).
+
+<VirtualHost *:443>
+
+  ServerName __LEIHS_EXTERNAL_HOSTNAME__
+
+  SSLEngine on
+  SSLCertificateFile /etc/ssl/certs/ssl-cert-snakeoil.pem
+  SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
+
+  SSLProxyEngine on
+  SSLProxyVerify none
+  SSLProxyCheckPeerCN off
+  SSLProxyCheckPeerName off
+
+  Header always set X-Content-Type-Options nosniff
+
+  Include /etc/apache2/leihs/conf.d/*.conf
+
+</VirtualHost>
+
+# --- START SHARED SSL CONFIG ---
+# Mozilla Guideline v5.6, Apache 2.4, intermediate configuration
+Header always set Strict-Transport-Security "max-age=63072000"
+
+# intermediate configuration
+SSLProtocol             all -SSLv3 -TLSv1 -TLSv1.1
+SSLCipherSuite          ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+SSLHonorCipherOrder     off
+SSLSessionTickets       off
+# --- END SHARED SSL CONFIG ---
+
+# vim: syntax=apache

--- a/docker/apache/webstats.conf
+++ b/docker/apache/webstats.conf
@@ -1,0 +1,28 @@
+# leihs-docker: Webstats-Fragment (AWStats)
+# Konvertiert aus leihs_deploy roles/webstats/templates/webstats.conf.
+# Wird von render-config.sh nach /etc/apache2/leihs/conf.d/ kopiert,
+# wenn WEBSTATS_ENABLED=true (Default).
+
+ProxyPass /webstats !
+ProxyPass /awstats.pl !
+
+Alias /webstats/icons "/usr/share/awstats/icon/"
+Alias /webstats/classes "/usr/share/awstats/lib/"
+Alias /webstats/css "/usr/share/doc/awstats/examples/css"
+
+ScriptAlias /webstats /usr/lib/cgi-bin/awstats.pl
+ScriptAlias /awstats.pl /usr/lib/cgi-bin/awstats.pl
+
+<Directory /usr/lib/cgi-bin/>
+    Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
+    AddHandler cgi-script .cgi
+</Directory>
+
+<Location /webstats>
+  AuthType Basic
+  AuthName "Webstats Access Required"
+  AuthUserFile /etc/leihs/webstats.htpasswd
+  require valid-user
+</Location>
+
+# vim: syntax=apache

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,0 +1,87 @@
+# leihs-docker — Compose configuration
+#
+# Default mode (split): PostgreSQL runs as its own container (db service),
+# the leihs app connects over TCP via the internal compose network
+# (DB_HOST=db). The DB port is NOT published to the host.
+#
+# Single-container mode: set DB_HOST=localhost and remove the db service —
+# the app then uses the PostgreSQL bundled inside the image (as with
+# docker run).
+#
+# Usage:
+#   cp docker/example.env .env        # optional: adjust values
+#   docker compose -f docker/compose.yaml up -d
+#
+# All ${VAR:-default} placeholders are read from .env (or --env-file);
+# without .env the defaults apply (identical to entrypoint.sh / Ansible defaults.yml).
+
+services:
+  db:
+    image: postgres:15
+    container_name: ${LEIHS_DB_CONTAINER_NAME:-leihs-db}
+    restart: unless-stopped
+    environment:
+      # Bootstrap superuser — must match the app's DB_USER (init-db.sh
+      # synchronizes password/privileges afterwards over TCP).
+      POSTGRES_USER: ${DB_USER:-root}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-root}
+      # Bootstrap database only; the actual leihs database is created by
+      # init-db.sh (ICU de-CH, template0, structure.sql + seeds.sql).
+      POSTGRES_DB: root
+    command: ["postgres", "-c", "port=${DB_PORT:-5415}"]
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -p ${DB_PORT:-5415} -d postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    # No ports: mapping — the DB is only reachable on the internal compose network.
+
+  leihs:
+    image: ${LEIHS_IMAGE:-leihs-docker:latest}
+    build:
+      context: ./docker
+    container_name: ${LEIHS_CONTAINER_NAME:-leihs}
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "${LEIHS_HTTP_PORT:-80}:80"
+      - "${LEIHS_HTTPS_PORT:-443}:443"
+    environment:
+      # Base
+      LEIHS_EXTERNAL_HOSTNAME: ${LEIHS_EXTERNAL_HOSTNAME:-leihs.example.org}
+      LEIHS_MASTER_SECRET: ${LEIHS_MASTER_SECRET:-}          # empty => auto-generated + persisted
+      # Database (Ansible defaults; change the password in production!)
+      # Split mode: DB_HOST=db (service name). Single container: DB_HOST=localhost.
+      DB_HOST: ${DB_HOST:-db}
+      DB_PORT: ${DB_PORT:-5415}
+      DB_NAME: ${DB_NAME:-leihs}
+      DB_USER: ${DB_USER:-root}
+      DB_PASSWORD: ${DB_PASSWORD:-root}
+      # Features
+      PUBLISH_INVENTORY: ${PUBLISH_INVENTORY:-false}
+      ENABLE_AUTH_HEADER_PREFIX_BASIC: ${ENABLE_AUTH_HEADER_PREFIX_BASIC:-true}
+      RESTRICT_ACCESS_VIA_BASIC_AUTH: ${RESTRICT_ACCESS_VIA_BASIC_AUTH:-false}
+      RESTRICT_ACCESS_VIA_BASIC_AUTH_PASSWORDS: ${RESTRICT_ACCESS_VIA_BASIC_AUTH_PASSWORDS:-}
+      WEBSTATS_ENABLED: ${WEBSTATS_ENABLED:-true}
+      # leihs-legacy (Puma)
+      LEIHS_PUMA_WORKERS: ${LEIHS_PUMA_WORKERS:-2}
+      LEIHS_PUMA_THREADS: ${LEIHS_PUMA_THREADS:-5}
+      # Cron (rake leihs:cron, daily)
+      LEIHS_CRON_TIME: ${LEIHS_CRON_TIME:-04:00}
+      LEIHS_CRON_RANDOMIZED_DELAY_MAX_SECONDS: ${LEIHS_CRON_RANDOMIZED_DELAY_MAX_SECONDS:-3600}
+    volumes:
+      - leihs-data:/leihs/var               # master_secret, DB backups
+      - leihs-storage:/leihs/legacy/storage # ActiveStorage uploads
+      # Own TLS certificates (optional, replace the snakeoil certificate):
+      # - ./certs/leihs.crt:/etc/ssl/certs/ssl-cert-snakeoil.pem:ro
+      # - ./certs/leihs.key:/etc/ssl/private/ssl-cert-snakeoil.key:ro
+
+volumes:
+  pgdata:
+  leihs-data:
+  leihs-storage:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# leihs-docker entrypoint (PID 1)
+#
+# Flow (mirrors the Ansible deployment leihs/leihs_deploy, install_play.yml):
+#   1. Set defaults/env variables (defaults.yml)
+#   2. Create/persist the master secret
+#   3. Render configuration (config.env, database.yml, puma.rb, Apache)
+#   4. Initialize PostgreSQL (cluster, role root, DB leihs, structure+seeds)
+#   5. Run migrations (leihs-migration.service)
+#   6. Start services (supervisor, like systemd Restart=always)
+#
+set -euo pipefail
+
+export LEIHS_ROOT_DIR="${LEIHS_ROOT_DIR:-/leihs}"
+
+# --- Defaults (mirror of leihs_deploy/defaults.yml) -----------------------------
+export LEIHS_EXTERNAL_HOSTNAME="${LEIHS_EXTERNAL_HOSTNAME:-leihs.example.org}"
+export LEIHS_SEND_MAILS="${LEIHS_SEND_MAILS:-No}"
+export LEIHS_CRON_TIME="${LEIHS_CRON_TIME:-04:00}"
+export LEIHS_CRON_RANDOMIZED_DELAY_MAX_SECONDS="${LEIHS_CRON_RANDOMIZED_DELAY_MAX_SECONDS:-3600}"
+
+export DB_HOST="${DB_HOST:-localhost}"
+export DB_PORT="${DB_PORT:-5415}"
+export DB_NAME="${DB_NAME:-leihs}"
+export DB_USER="${DB_USER:-root}"
+export DB_PASSWORD="${DB_PASSWORD:-root}"
+
+export ENABLE_AUTH_HEADER_PREFIX_BASIC="${ENABLE_AUTH_HEADER_PREFIX_BASIC:-true}"
+export PUBLISH_INVENTORY="${PUBLISH_INVENTORY:-false}"
+export WEBSTATS_ENABLED="${WEBSTATS_ENABLED:-true}"
+export RESTRICT_ACCESS_VIA_BASIC_AUTH="${RESTRICT_ACCESS_VIA_BASIC_AUTH:-false}"
+export RESTRICT_ACCESS_VIA_BASIC_AUTH_PASSWORDS="${RESTRICT_ACCESS_VIA_BASIC_AUTH_PASSWORDS:-}"
+
+export LEIHS_PUMA_WORKERS="${LEIHS_PUMA_WORKERS:-2}"
+export LEIHS_PUMA_THREADS="${LEIHS_PUMA_THREADS:-5}"
+
+# HTTP ports (Ansible defaults; configurable per service)
+export LEIHS_LEGACY_HTTP_PORT="${LEIHS_LEGACY_HTTP_PORT:-3210}"
+export LEIHS_ADMIN_HTTP_PORT="${LEIHS_ADMIN_HTTP_PORT:-3220}"
+export LEIHS_PROCURE_HTTP_PORT="${LEIHS_PROCURE_HTTP_PORT:-3230}"
+export LEIHS_PROCURE_CLIENT_HTTP_PORT="${LEIHS_PROCURE_CLIENT_HTTP_PORT:-3231}"
+export LEIHS_MY_HTTP_PORT="${LEIHS_MY_HTTP_PORT:-3240}"
+export LEIHS_BORROW_HTTP_PORT="${LEIHS_BORROW_HTTP_PORT:-3250}"
+export LEIHS_INVENTORY_HTTP_PORT="${LEIHS_INVENTORY_HTTP_PORT:-3260}"
+
+# Java heap per service (Ansible defaults)
+export LEIHS_JAVA_XMX_ADMIN="${LEIHS_JAVA_XMX_ADMIN:-1G}"
+export LEIHS_JAVA_XMX_BORROW="${LEIHS_JAVA_XMX_BORROW:-1G}"
+export LEIHS_JAVA_XMX_PROCURE="${LEIHS_JAVA_XMX_PROCURE:-1G}"
+export LEIHS_JAVA_XMX_MY="${LEIHS_JAVA_XMX_MY:-500m}"
+export LEIHS_JAVA_XMX_MAIL="${LEIHS_JAVA_XMX_MAIL:-500m}"
+export LEIHS_JAVA_XMX_INVENTORY="${LEIHS_JAVA_XMX_INVENTORY:-1G}"
+export LEIHS_DB_MAX_POOL_SIZE="${LEIHS_DB_MAX_POOL_SIZE:-20}"
+
+# --- Master secret ----------------------------------------------------------------
+# From env or persisted in /leihs/var/master_secret (like inventory/master_secret.txt)
+if [ -z "${LEIHS_MASTER_SECRET:-}" ]; then
+  mkdir -p "${LEIHS_ROOT_DIR}/var"
+  SECRET_FILE="${LEIHS_ROOT_DIR}/var/master_secret"
+  if [ ! -s "${SECRET_FILE}" ]; then
+    tr -dc 'A-Za-z0-9' </dev/urandom | head -c 40 > "${SECRET_FILE}"
+    chmod 600 "${SECRET_FILE}"
+  fi
+  export LEIHS_MASTER_SECRET="$(cat "${SECRET_FILE}")"
+fi
+
+# --- LEIHS_VERSION (build arg or unknown) ------------------------------------------
+export LEIHS_VERSION="${LEIHS_VERSION:-${LEIHS_VERSION_BUILD:-unknown}}"
+
+echo "[leihs] version=${LEIHS_VERSION} ref=${LEIHS_VERSION_BUILD:-?} hostname=${LEIHS_EXTERNAL_HOSTNAME}"
+
+# --- Render configuration -------------------------------------------------------------
+/usr/local/lib/leihs/render-config.sh
+
+# --- Initialize database + migrate ------------------------------------------------------
+/usr/local/lib/leihs/init-db.sh
+
+# --- Start services (supervisor, stays PID 1) ---------------------------------------------
+exec /usr/local/lib/leihs/start-services.sh

--- a/docker/example.env
+++ b/docker/example.env
@@ -1,0 +1,78 @@
+# leihs-docker — example configuration
+#
+# Usage:
+#   cp docker/example.env .env
+#   # adjust .env (all values optional — defaults see comments)
+#   docker compose -f docker/compose.yaml up -d
+#
+# The defaults correspond to the Ansible deployment (leihs_deploy/defaults.yml)
+# respectively entrypoint.sh. Commented lines = default; just activate them.
+
+# ─── Base ───────────────────────────────────────────────────────────────────
+# Public hostname (ServerName of the Apache vhosts)
+LEIHS_EXTERNAL_HOSTNAME=leihs.example.org
+
+# Master secret for Rails/jars (40 chars). Leave empty => generated on first
+# start and persisted in /leihs/var/master_secret.
+# LEIHS_MASTER_SECRET=
+
+# Image tag (default: locally built "leihs-docker:latest")
+# LEIHS_IMAGE=leihs-docker:latest
+# LEIHS_CONTAINER_NAME=leihs
+
+# ─── Ports ──────────────────────────────────────────────────────────────────
+# LEIHS_HTTP_PORT=80
+# LEIHS_HTTPS_PORT=443
+
+# ─── Database (IMPORTANT: change the password in production!) ───────────────
+# Two modes:
+#   Split (compose default):  DB_HOST=db   → PostgreSQL as its own container
+#                              (db service, internal port ${DB_PORT:-5415},
+#                               no port exposed to the host).
+#   Single container:         DB_HOST=localhost → the PostgreSQL bundled in
+#                              the image is used (remove the db service).
+# init-db.sh talks to the database over TCP (DB_HOST:DB_PORT) in both modes —
+# the local cluster is only started when DB_HOST=localhost.
+# DB_HOST=db
+# DB_PORT=5415
+# DB_NAME=leihs
+# DB_USER=root
+DB_PASSWORD=root
+# Name of the DB container (split mode)
+# LEIHS_DB_CONTAINER_NAME=leihs-db
+# Note: In split mode the db service takes POSTGRES_USER/POSTGRES_PASSWORD
+# from DB_USER/DB_PASSWORD (see compose.yaml).
+
+# ─── Features ───────────────────────────────────────────────────────────────
+# Enable the leihs-inventory service + /inventory route
+# PUBLISH_INVENTORY=false
+# API basic auth header prefix (config.env: ENABLE_AUTH_HEADER_PREFIX_BASIC)
+# ENABLE_AUTH_HEADER_PREFIX_BASIC=true
+# Protect the whole access with basic auth (exceptions: /webstats, /admin)
+# RESTRICT_ACCESS_VIA_BASIC_AUTH=false
+# RESTRICT_ACCESS_VIA_BASIC_AUTH_PASSWORDS=user:pass,user2:pass2
+# AWStats under /webstats
+# WEBSTATS_ENABLED=true
+
+# ─── leihs-legacy (Puma) ────────────────────────────────────────────────────
+# LEIHS_PUMA_WORKERS=2
+# LEIHS_PUMA_THREADS=5
+
+# ─── Cron (rake leihs:cron, daily with random delay) ────────────────────────
+# LEIHS_CRON_TIME=04:00
+# LEIHS_CRON_RANDOMIZED_DELAY_MAX_SECONDS=3600
+
+# ─── Java heaps & DB pool (Ansible defaults) ────────────────────────────────
+# LEIHS_JAVA_XMX_ADMIN=1G
+# LEIHS_JAVA_XMX_BORROW=1G
+# LEIHS_JAVA_XMX_PROCURE=1G
+# LEIHS_JAVA_XMX_MY=500m
+# LEIHS_JAVA_XMX_MAIL=500m
+# LEIHS_JAVA_XMX_INVENTORY=1G
+# LEIHS_DB_MAX_POOL_SIZE=20
+
+# ─── Misc ───────────────────────────────────────────────────────────────────
+# Seed for IP anonymization in the Apache access log (default: hostname)
+# LEIHS_IP_HASH_SEED=
+# Controls email sending of the nightly tasks (Ansible variable leihs_send_mails)
+# LEIHS_SEND_MAILS=No

--- a/docker/scripts/init-db.sh
+++ b/docker/scripts/init-db.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# init-db.sh — database bootstrap: role, DB leihs, structure/seeds, migrations.
+#
+# All client logic runs over TCP against ${DB_HOST}:${DB_PORT} — a single code
+# path, regardless of whether PostgreSQL runs in the same container
+# (DB_HOST=localhost, single-container mode) or as a separate container
+# (compose split, DB_HOST=<service name>).
+#
+# The local cluster is only ensured when DB_HOST points to localhost
+# (server side only: create/start the cluster). All client steps (role,
+# databases, structure/seeds, migrations) go over TCP.
+#
+# Corresponds to the Ansible steps:
+#   roles/postgresql             (pgdg PG15, port 5415)
+#   roles/leihs-database-install (role root, DB leihs, structure.sql + seeds.sql)
+#   leihs-migration.service      (bundle exec rake db:migrate)
+#
+# Idempotent: runs on every container start; existing data is preserved.
+#
+set -euo pipefail
+
+log() { echo "[leihs:db] $*" >&2; }
+
+# --- 0. Single-container mode only: ensure the local cluster ------------------------
+case "${DB_HOST}" in
+  localhost|127.0.0.1|::1)
+    PGVERSION=$(ls /usr/lib/postgresql/ | sort -V | tail -1)
+    export PGVERSION
+    PGBIN="/usr/lib/postgresql/${PGVERSION}/bin"
+    PGDATA="/var/lib/postgresql/${PGVERSION}/main"
+    export PGDATA
+
+    if [ ! -x "${PGBIN}/postgres" ]; then
+      echo "[leihs:db] ERROR: PostgreSQL binaries not found under ${PGBIN}" >&2
+      exit 1
+    fi
+
+    if [ ! -s "${PGDATA}/PG_VERSION" ]; then
+      log "no cluster at ${PGDATA} — creating a new cluster"
+      mkdir -p /var/lib/postgresql
+      pg_createcluster "${PGVERSION}" main --start >/dev/null 2>&1 || \
+        ( su postgres -c "${PGBIN}/initdb -D ${PGDATA} -E UTF8 --locale=C.UTF-8" >/dev/null 2>&1 \
+          && log "cluster created via initdb" )
+    fi
+
+    PGCONF="/etc/postgresql/${PGVERSION}/main/postgresql.conf"
+    if ! grep -qE "^port = ${DB_PORT}$" "${PGCONF}"; then
+      sed -i "s/^#\?port = .*/port = ${DB_PORT}/" "${PGCONF}"
+      log "port ${DB_PORT} set in ${PGCONF}"
+    fi
+
+    if ! pg_isready -q -h localhost -p "${DB_PORT}" 2>/dev/null; then
+      pg_ctlcluster "${PGVERSION}" main start || pg_ctlcluster "${PGVERSION}" main restart
+    fi
+
+    # Create the initial superuser ${DB_USER} — local first-bootstrap only, via
+    # the postgres OS user (peer auth on the unix socket). In split mode the
+    # postgres image does this (POSTGRES_USER). Everything after this is TCP.
+    su postgres -c "psql -p ${DB_PORT} -v ON_ERROR_STOP=1 -q" <<SQL
+DO \$\$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${DB_USER}') THEN
+    CREATE ROLE ${DB_USER} SUPERUSER CREATEDB LOGIN PASSWORD '${DB_PASSWORD}';
+  ELSE
+    ALTER ROLE ${DB_USER} WITH SUPERUSER CREATEDB LOGIN PASSWORD '${DB_PASSWORD}';
+  END IF;
+END
+\$\$;
+SQL
+    ;;
+esac
+
+# --- 1. Wait for the database (always TCP) ---------------------------------------------
+for _ in $(seq 1 60); do
+  pg_isready -q -h "${DB_HOST}" -p "${DB_PORT}" && break
+  sleep 1
+done
+pg_isready -q -h "${DB_HOST}" -p "${DB_PORT}" \
+  || { echo "[leihs:db] PostgreSQL ${DB_HOST}:${DB_PORT} not reachable" >&2; exit 1; }
+log "PostgreSQL reachable: ${DB_HOST}:${DB_PORT}"
+
+export PGPASSWORD="${DB_PASSWORD}"
+PSQL=(psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -v ON_ERROR_STOP=1 -q)
+
+# --- 2. Ensure role ${DB_USER} (idempotent, over TCP) -----------------------------------
+# Exists in both modes already (local: step 0; remote: POSTGRES_USER of the
+# postgres image) — here only password and privileges are synchronized.
+"${PSQL[@]}" -d postgres <<SQL
+DO \$\$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${DB_USER}') THEN
+    CREATE ROLE ${DB_USER} SUPERUSER CREATEDB LOGIN PASSWORD '${DB_PASSWORD}';
+  ELSE
+    ALTER ROLE ${DB_USER} WITH SUPERUSER CREATEDB LOGIN PASSWORD '${DB_PASSWORD}';
+  END IF;
+END
+\$\$;
+SQL
+
+# --- 3. Ensure database 'root' (root_user.yml) --------------------------------------------
+DB_ROOT_EXISTS=$("${PSQL[@]}" -d postgres -AXtqc "SELECT 1 FROM pg_database WHERE datname='root'")
+if [ "${DB_ROOT_EXISTS}" != "1" ]; then
+  "${PSQL[@]}" -d postgres -qc "CREATE DATABASE root OWNER ${DB_USER}"
+  log "database 'root' created"
+fi
+
+# --- 4. Create the leihs database + structure/seeds (create-and-seed.yml) -----------------
+DB_EXISTS=$("${PSQL[@]}" -d postgres -AXtqc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'")
+if [ "${DB_EXISTS}" != "1" ]; then
+  log "database '${DB_NAME}' does not exist — creating (ICU de-CH, UTF8, template0)"
+  "${PSQL[@]}" -d postgres -qc "CREATE DATABASE ${DB_NAME} OWNER ${DB_USER} ENCODING 'UTF8' TEMPLATE template0 LOCALE_PROVIDER icu ICU_LOCALE 'de-CH'"
+
+  log "loading structure.sql"
+  "${PSQL[@]}" -d "${DB_NAME}" -f "${LEIHS_ROOT_DIR}/database/db/structure.sql"
+
+  log "loading seeds.sql (session_replication_role=REPLICA)"
+  "${PSQL[@]}" -d "${DB_NAME}" \
+    -c "SET session_replication_role = REPLICA;" \
+    -f "${LEIHS_ROOT_DIR}/database/db/seeds.sql" \
+    -c "SET session_replication_role = DEFAULT;"
+  log "database '${DB_NAME}' initialized (structure + seeds)"
+else
+  log "database '${DB_NAME}' already exists — skipping structure/seeds"
+fi
+
+# --- 5. Migrations (leihs-migration.service) ------------------------------------------------
+log "running migrations (rake db:migrate)"
+cd "${LEIHS_ROOT_DIR}/database"
+set -a
+# shellcheck disable=SC1091
+source /etc/leihs/config.env
+set +a
+export RAILS_ENV=production
+export LEIHS_SECRET="${LEIHS_MASTER_SECRET}"
+export SECRET_KEY_BASE="${LEIHS_MASTER_SECRET}"
+export RAILS_LOG_LEVEL=WARN
+export PATH="/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+bundle exec rake db:migrate
+log "migrations complete"

--- a/docker/scripts/render-config.sh
+++ b/docker/scripts/render-config.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# render-config.sh — renders all leihs configuration from environment variables.
+#
+# Corresponds to the Ansible templates from leihs_deploy (roles/configure,
+# roles/leihs-legacy-install, roles/reverse-proxy-leihs, roles/webstats).
+#
+set -euo pipefail
+
+log() { echo "[leihs:config] $*"; }
+
+mkdir -p /etc/leihs /etc/apache2/leihs/conf.d "${LEIHS_ROOT_DIR}/config" /var/log/leihs
+
+# ---------------------------------------------------------------------------
+# /etc/leihs/config.env — environment for all Java services (config.env template)
+# ---------------------------------------------------------------------------
+cat > /etc/leihs/config.env <<EOF
+DB_HOST=${DB_HOST}
+DB_PORT=${DB_PORT}
+DB_NAME=${DB_NAME}
+DB_USER=${DB_USER}
+DB_PASSWORD=${DB_PASSWORD}
+
+ENABLE_AUTH_HEADER_PREFIX_BASIC=${ENABLE_AUTH_HEADER_PREFIX_BASIC}
+
+LEIHS_VERSION=${LEIHS_VERSION}
+EOF
+chmod 600 /etc/leihs/config.env
+log "config.env written"
+
+# ---------------------------------------------------------------------------
+# /leihs/config/database.yml — central DB config (configure role)
+# ---------------------------------------------------------------------------
+cat > "${LEIHS_ROOT_DIR}/config/database.yml" <<EOF
+database:
+	host: ${DB_HOST}
+	port: ${DB_PORT}
+	username: ${DB_USER}
+	password: ${DB_PASSWORD}
+	database: ${DB_NAME}
+EOF
+chmod 600 "${LEIHS_ROOT_DIR}/config/database.yml"
+
+# ---------------------------------------------------------------------------
+# /leihs/legacy/config/database.yml (leihs-legacy-install database.yml)
+# ---------------------------------------------------------------------------
+cat > "${LEIHS_ROOT_DIR}/legacy/config/database.yml" <<EOF
+production:
+  adapter: postgresql
+  host: ${DB_HOST}
+  port: ${DB_PORT}
+  pool: 25
+  encoding: unicode
+  username: ${DB_USER}
+  password: ${DB_PASSWORD}
+  database: ${DB_NAME}
+EOF
+chmod 600 "${LEIHS_ROOT_DIR}/legacy/config/database.yml"
+log "database.yml written"
+
+# ---------------------------------------------------------------------------
+# /leihs/database/config/database.yml (leihs-database-install database.yml)
+# Used by the migration app (rake db:migrate).
+# ---------------------------------------------------------------------------
+mkdir -p "${LEIHS_ROOT_DIR}/database/config"
+cat > "${LEIHS_ROOT_DIR}/database/config/database.yml" <<EOF
+production: &DEFAULT
+  adapter: postgresql
+  host: ${DB_HOST}
+  port: ${DB_PORT}
+  pool: 25
+  encoding: unicode
+  username: ${DB_USER}
+  password: ${DB_PASSWORD}
+  database: ${DB_NAME}
+development:
+  <<: *DEFAULT
+EOF
+chmod 600 "${LEIHS_ROOT_DIR}/database/config/database.yml"
+log "database.yml (database app) written"
+
+# ---------------------------------------------------------------------------
+# /leihs/legacy/config/puma.rb (puma.rb template)
+# ---------------------------------------------------------------------------
+cat > "${LEIHS_ROOT_DIR}/legacy/config/puma.rb" <<EOF
+workers(${LEIHS_PUMA_WORKERS})
+threads(1,${LEIHS_PUMA_THREADS})
+bind("tcp://localhost:${LEIHS_LEGACY_HTTP_PORT}")
+environment("production")
+EOF
+log "puma.rb written (workers=${LEIHS_PUMA_WORKERS}, threads=${LEIHS_PUMA_THREADS})"
+
+# ---------------------------------------------------------------------------
+# Apache2: directories + modules + default certificate
+# ---------------------------------------------------------------------------
+mkdir -p /etc/apache2/leihs/conf.d /var/run/apache2 /var/lock/apache2
+if [ ! -e /etc/ssl/private/ssl-cert-snakeoil.key ]; then
+  make-ssl-cert generate-default-snakeoil --force-overwrite 2>/dev/null || true
+fi
+
+# Main config (leihs-main.conf): render IP_HASH_SEED + inventory route
+SEED="${LEIHS_IP_HASH_SEED:-$(hostname)}"
+sed "s|__IP_HASH_SEED__|${SEED}|g" /etc/apache2/leihs/leihs-main.conf > /etc/apache2/leihs/leihs-main.conf.rendered
+if [ "${PUBLISH_INVENTORY}" = "true" ]; then
+  sed -i "s|^#\?\s*ProxyPass /inventory|ProxyPass /inventory|" /etc/apache2/leihs/leihs-main.conf.rendered
+else
+  sed -i "s|^ProxyPass /inventory|#ProxyPass /inventory|" /etc/apache2/leihs/leihs-main.conf.rendered
+fi
+mv /etc/apache2/leihs/leihs-main.conf.rendered /etc/apache2/leihs/leihs-main.conf
+
+# Virtual hosts (http.conf/https.conf templates)
+sed "s|__LEIHS_EXTERNAL_HOSTNAME__|${LEIHS_EXTERNAL_HOSTNAME}|g" \
+    /etc/apache2/leihs/vhost-http.conf.tpl > /etc/apache2/sites-available/leihs-http.conf
+sed "s|__LEIHS_EXTERNAL_HOSTNAME__|${LEIHS_EXTERNAL_HOSTNAME}|g" \
+    /etc/apache2/leihs/vhost-https.conf.tpl > /etc/apache2/sites-available/leihs-https.conf
+
+# conf.d fragments (included from both vhosts)
+rm -f /etc/apache2/leihs/conf.d/*.conf
+
+# Webstats (webstats.conf) — optional, default on
+if [ "${WEBSTATS_ENABLED}" = "true" ]; then
+  cp /etc/apache2/leihs/webstats.conf /etc/apache2/leihs/conf.d/leihs_100_webstats.conf
+  # adjust awstats configuration (like the webstats role)
+  sed -i "s|^LogFile=.*|LogFile=\"/var/log/apache2/leihs_${LEIHS_EXTERNAL_HOSTNAME}_access.log\"|" /etc/awstats/awstats.conf
+  sed -i "s|^SiteDomain=.*|SiteDomain=\"${LEIHS_EXTERNAL_HOSTNAME}\"|" /etc/awstats/awstats.conf
+  log "webstats enabled"
+else
+  log "webstats disabled"
+fi
+
+# Basic auth (optional, default off)
+if [ "${RESTRICT_ACCESS_VIA_BASIC_AUTH}" = "true" ]; then
+  sed "s|__LEIHS_EXTERNAL_HOSTNAME__|${LEIHS_EXTERNAL_HOSTNAME}|g" \
+      /etc/apache2/leihs/basic-auth.conf.tpl > /etc/apache2/leihs/conf.d/leihs_950_basic_auth.conf
+  : > /etc/leihs/leihs.htpasswd
+  # Format: "user:pass,user2:pass2"
+  IFS=',' read -ra ENTRIES <<< "${RESTRICT_ACCESS_VIA_BASIC_AUTH_PASSWORDS}"
+  for entry in "${ENTRIES[@]}"; do
+    user="${entry%%:*}"
+    pass="${entry#*:}"
+    [ -n "${user}" ] && htpasswd -b /etc/leihs/leihs.htpasswd "${user}" "${pass}"
+  done
+  log "basic auth enabled (${#ENTRIES[@]} users)"
+else
+  log "basic auth disabled"
+fi
+
+# a2ensite + configuration test
+a2ensite leihs-http >/dev/null 2>&1 || true
+a2ensite leihs-https >/dev/null 2>&1 || true
+a2dissite 000-default >/dev/null 2>&1 || true
+apache2ctl -t >/dev/null 2>&1 || { echo "[leihs:config] Apache config test failed:"; apache2ctl -t; exit 1; }
+log "Apache configuration valid"
+
+# ---------------------------------------------------------------------------
+# Ensure directories (logs/tmp)
+# ---------------------------------------------------------------------------
+mkdir -p "${LEIHS_ROOT_DIR}/legacy/log" "${LEIHS_ROOT_DIR}/legacy/tmp" "${LEIHS_ROOT_DIR}/legacy/storage"
+mkdir -p "${LEIHS_ROOT_DIR}/database/log" "${LEIHS_ROOT_DIR}/database/tmp"
+for svc in admin borrow procure my mail inventory; do
+  mkdir -p "${LEIHS_ROOT_DIR}/${svc}/logs" "${LEIHS_ROOT_DIR}/${svc}/tmp"
+done
+mkdir -p "${LEIHS_ROOT_DIR}/var/db-backups"
+log "directories created"

--- a/docker/scripts/start-services.sh
+++ b/docker/scripts/start-services.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# start-services.sh — supervisor for all leihs services.
+#
+# Replicates the systemd units from leihs_deploy:
+#   leihs-migration.service (already ran in init-db.sh, RemainAfterExit)
+#   leihs-admin/borrow/procure/my/mail/inventory.service (Restart=always)
+#   leihs-legacy.service          (puma, Restart=always)
+#   leihs-legacy-cron.timer       (rake leihs:cron, daily)
+#   apache2 (reverse-proxy-leihs)
+#
+# Behavior: every service runs in a restart loop (like systemd
+# Restart=always). On SIGTERM/SIGINT all children are shut down cleanly.
+#
+set -uo pipefail
+
+log() { echo "[leihs:svc] $(date -Is) $*"; }
+
+# --- global service environment ---------------------------------------------------
+set -a
+# shellcheck disable=SC1091
+source /etc/leihs/config.env
+set +a
+export JAVA_HOME=/opt/java
+export PATH="/opt/ruby/bin:/opt/java/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+# --- restart loop (equivalent to systemd Restart=always) ----------------------------
+# "$@" is executed in the same shell process (run_* use `exec`), so the process
+# can be observed directly.
+supervise() {
+  local name="$1"; shift
+  local pid rc
+  while :; do
+    "$@" >> "/var/log/leihs/${name}.log" 2>&1 &
+    pid=$!
+    log "${name} started (pid ${pid})"
+    wait "${pid}" 2>/dev/null
+    rc=$?
+    if [ -f /tmp/leihs-shutdown ]; then
+      log "${name} stopped (rc=${rc}) — shutdown"
+      return 0
+    fi
+    log "${name} exited (rc=${rc}) — restart in 5s"
+    sleep 5
+  done
+}
+
+# --- Services ------------------------------------------------------------------------
+
+# Apache2 reverse proxy (vhosts were enabled in render-config.sh)
+supervise apache2 apache2ctl -DFOREGROUND &
+SUPERVISORS+=("$!")
+
+# Tail Apache logs to stdout (container visibility; -F waits for file appearance)
+( tail -n +1 -F "/var/log/apache2/leihs_${LEIHS_EXTERNAL_HOSTNAME}_error.log" \
+          "/var/log/apache2/leihs_${LEIHS_EXTERNAL_HOSTNAME}_access.log" \
+    2>/dev/null >> "/var/log/leihs/apache2-logs.stdout" ) &
+SUPERVISORS+=("$!")
+
+# leihs-legacy (Puma, Rails) — leihs-legacy.service
+run_legacy() {
+  cd "${LEIHS_ROOT_DIR}/legacy" || exit 1
+  export LEIHS_SECRET="${LEIHS_MASTER_SECRET}"
+  export SECRET_KEY_BASE="${LEIHS_MASTER_SECRET}"
+  export RAILS_LOG_LEVEL=WARN
+  export RAILS_ENV=production
+  export RAILS_SERVE_STATIC_FILES=Yes
+  export LEIHS_SHOW_NEW_INVENTORY_BUTTON=$([ "${PUBLISH_INVENTORY:-false}" = "true" ] && echo true || echo false)
+  exec bundle exec puma -C config/puma.rb
+}
+supervise legacy run_legacy &
+SUPERVISORS+=("$!")
+
+# Java services (fat jars) — leihs-*.service
+run_jar() {
+  local name="$1" xmx="$2" pool="$3" port="$4"
+  cd "${LEIHS_ROOT_DIR}/${name}" || exit 1
+  export HTTP_PORT="${port}"
+  export DB_MAX_POOL_SIZE="${pool}"
+  exec java "-Xmx${xmx}" -jar "leihs-${name}.jar" run
+}
+
+supervise admin   run_jar admin   "${LEIHS_JAVA_XMX_ADMIN}"    "${LEIHS_DB_MAX_POOL_SIZE}" "${LEIHS_ADMIN_HTTP_PORT}" &
+SUPERVISORS+=("$!")
+supervise borrow  run_jar borrow  "${LEIHS_JAVA_XMX_BORROW}"   "${LEIHS_DB_MAX_POOL_SIZE}" "${LEIHS_BORROW_HTTP_PORT}" &
+SUPERVISORS+=("$!")
+supervise procure run_jar procure "${LEIHS_JAVA_XMX_PROCURE}"  "${LEIHS_DB_MAX_POOL_SIZE}" "${LEIHS_PROCURE_HTTP_PORT}" &
+SUPERVISORS+=("$!")
+supervise my      run_jar my      "${LEIHS_JAVA_XMX_MY}"       10                          "${LEIHS_MY_HTTP_PORT}" &
+SUPERVISORS+=("$!")
+supervise mail    run_jar mail    "${LEIHS_JAVA_XMX_MAIL}"     10                          "" &
+SUPERVISORS+=("$!")
+
+# leihs-inventory only when PUBLISH_INVENTORY=true (start-services.yml)
+if [ "${PUBLISH_INVENTORY:-false}" = "true" ]; then
+  supervise inventory run_jar inventory "${LEIHS_JAVA_XMX_INVENTORY}" "${LEIHS_DB_MAX_POOL_SIZE}" "${LEIHS_INVENTORY_HTTP_PORT}" &
+  SUPERVISORS+=("$!")
+  log "inventory service enabled (PUBLISH_INVENTORY=true)"
+else
+  log "inventory service disabled (PUBLISH_INVENTORY != true)"
+fi
+
+# --- cron loop (leihs-legacy-cron.timer, daily) ------------------------------------------
+cron_loop() {
+  local now next delay
+  while :; do
+    now=$(date +%s)
+    next=$(date -d "today ${LEIHS_CRON_TIME}" +%s 2>/dev/null) || next=0
+    if [ "${next}" -le "${now}" ]; then
+      next=$(date -d "tomorrow ${LEIHS_CRON_TIME}" +%s)
+    fi
+    delay=$(( RANDOM % LEIHS_CRON_RANDOMIZED_DELAY_MAX_SECONDS ))
+    log "cron: next run at $(date -d "@$(( next + delay ))" '+%Y-%m-%d %H:%M:%S')"
+    sleep "$(( next - now + delay ))"
+    [ -f /tmp/leihs-shutdown ] && return 0
+    log "cron: rake leihs:cron"
+    (
+      cd "${LEIHS_ROOT_DIR}/legacy" || exit 1
+      export LEIHS_SECRET="${LEIHS_MASTER_SECRET}"
+      export SECRET_KEY_BASE="${LEIHS_MASTER_SECRET}"
+      export RAILS_LOG_LEVEL=WARN
+      export RAILS_ENV=production
+      export PATH="/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      bundle exec rake leihs:cron
+    ) >> "/var/log/leihs/cron.log" 2>&1
+  done
+}
+supervise cron cron_loop &
+SUPERVISORS+=("$!")
+
+# --- signal handling ----------------------------------------------------------------------
+shutdown() {
+  log "SIGTERM received — stopping all services"
+  touch /tmp/leihs-shutdown
+  apache2ctl stop >/dev/null 2>&1 || true
+  pkill -TERM -x java 2>/dev/null || true          # leihs-*.jar
+  pkill -TERM -f 'puma' 2>/dev/null || true        # leihs-legacy
+  pkill -TERM -x sleep 2>/dev/null || true         # cron/restart loops
+  sleep 3
+  pkill -KILL -x java 2>/dev/null || true
+  pkill -KILL -f 'puma' 2>/dev/null || true
+  pkill -TERM -f 'tail -n +1 -F' 2>/dev/null || true
+  log "all services stopped"
+}
+trap shutdown TERM INT
+
+log "all services started. container ready."
+wait
+exit 0


### PR DESCRIPTION
### Summary
Adds a Docker deployment under [`docker/`](https://github.com/tilllt/leihs/blob/feat/docker-deployment/docker/README.md) — see issue #2238 for the proposal and open questions. It converts the Ansible deployment ([leihs_deploy](https://github.com/leihs/leihs_deploy)) into containers without changing the service layout or the configuration variables.

### What's included
- **`docker/Dockerfile`** — two-stage build (mise toolchain, Clojure fat jars, Ruby `vendor/bundle`), pinned to the same `leihs/leihs` revisions the Ansible deploy would use. The build clones the super-repo (incl. submodules) at build time, so no source files are needed in the build context.
- **`docker/entrypoint.sh` + `docker/scripts/`** — idempotent startup mirroring the Ansible roles: render-config (`config.env` incl. `DB_HOST`, `database.yml` for legacy **and** the database app, `puma.rb`, Apache vhosts), init-db (role `root`, DB `leihs` with ICU `de-CH`, `structure.sql`/`seeds.sql`, migrations), supervisor with `Restart=always` behavior.
- **`docker/compose.yaml`** — split mode as default: PostgreSQL 15 as its own container on the internal network (no port exposed to the host), healthcheck + `depends_on`. The image keeps the bundled PostgreSQL for the single-container mode.
- **`docker/README.md`**, `docker/example.env`, Apache templates, root README section, `/.env` gitignore entry.

### Design notes
- All database client logic runs over **TCP** (`DB_HOST:DB_PORT`) — the Java services already read `DB_HOST` via `leihs.core.db` — so there is a single code path for both the single-container and the split mode.
- Defaults mirror `leihs_deploy/defaults.yml` (DB port 5415, user `root`, DB `leihs`, ICU `de-CH`).

### Verification
- The image builds successfully in CI on the reference implementation (public mirror: https://github.com/tilllt/leihs-docker).
- A full runtime smoke test is still pending on my side and will be reported here once done.

Happy to adjust scope, move this to `leihs_deploy`, or add a CI workflow if maintainers prefer.

Refs: #2238

---

*Note: this PR was drafted with assistance from an AI agent (Hermes by Nous Research) on behalf of the contributor.*